### PR TITLE
Fixing up edge cases with influxdb's new line protocol

### DIFF
--- a/logstash-output-influxdb.gemspec
+++ b/logstash-output-influxdb.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-influxdb'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you output Metrics to InfluxDB"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Based on the spec https://influxdb.com/docs/v0.9/write_protocols/write_syntax.html

I am just implementing this rule

```
Escaping Characters
If a tag key, tag value, or field key contains a space , comma ,, or an equals sign = it must be escaped using the backslash character \. Backslash characters do not need to be escaped. Commas , and spaces will also need to be escaped for measurements, though equals signs = do not.
```

Let me know if you want more unit tests
